### PR TITLE
Fix env copy failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ Perfect for documentation workflows, version control of notebook content, or any
 pipx install . --force
 ```
 
+On first run, the sample configuration at
+`src/notebook2md/configs/.env.example` will be copied to
+`~/.repo2readme/.env`. Update the values inside this file to provide your
+`MODEL_ID` and OpenRouter credentials.
+
 ## 🛠️ Usage
 
 After installation, you can use notebook2md directly from the command line:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,6 @@ notebook2md = "notebook2md.main:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/notebook2md"]
+
+[tool.hatch.build]
+include = ["src/notebook2md/configs/.env.example"]

--- a/src/notebook2md/configs/.env.example
+++ b/src/notebook2md/configs/.env.example
@@ -1,0 +1,4 @@
+# Example configuration for notebook2md
+MODEL_ID=your-model-id
+OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
+OPENROUTER_API_KEY=your-api-key

--- a/src/notebook2md/main.py
+++ b/src/notebook2md/main.py
@@ -37,7 +37,8 @@ def setup_env():
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
     if not ENV_PATH.exists():
         try:
-            shutil.copy(Path(__file__).parent / "configs" / ".env.example", ENV_PATH)
+            example = Path(__file__).parent / "configs" / ".env.example"
+            shutil.copy(example, ENV_PATH)
             log(GREEN, f"✅ Created default env: {ENV_PATH}")
             print(f"⚠️  Edit with: nano {ENV_PATH}")
         except Exception as e:


### PR DESCRIPTION
## Summary
- copy `.env` from `.env.example` without fallback
- document that config file is copied from `.env.example`

## Testing
- `python -m pip install -e .`
- `/root/.pyenv/versions/3.12.10/bin/notebook2md sample.ipynb | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68656a6a27988332a42c91ce8f36ff51